### PR TITLE
Improved config client to support values from files, files and to populate the input struct.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
+	github.com/imdario/mergo v0.3.11
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/prometheus/client_golang v1.8.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -20,9 +20,11 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -171,8 +173,14 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
+github.com/iancoleman/strcase v0.1.2 h1:gnomlvw9tnV3ITTAxzKSgTF+8kFWcU/f+TgttpXGz1U=
+github.com/iancoleman/strcase v0.1.2/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jeremywohl/flatten v1.0.1 h1:LrsxmB3hfwJuE+ptGOijix1PIfOoKLJ3Uee/mzbgtrs=
+github.com/jeremywohl/flatten v1.0.1/go.mod h1:4AmD/VxjWcI5SRB0n6szE2A6s2fsNHDLO0nAlMHgfLQ=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -505,6 +513,7 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/tmpl/config.go.tmpl
+++ b/internal/tmpl/config.go.tmpl
@@ -2,7 +2,6 @@ package config
 
 import (
     handlers2 "{{.Name}}/pkg/handlers"
-	"fmt"
 	"net/http"
 
 
@@ -23,26 +22,14 @@ type Config struct {
 	RateInterval          int  `env:"RATE_INTERVAL" default:"{{.RateInterval}}"`
 }
 
-//getViperConfig will use Viper to populate the Config struct
-func getViperConfig() (*Config, error) {
-	cfgInt, err := config.LoadViperConfig(Config{})
-	if err != nil {
-		return nil, err
-	}
-	cfg, ok := cfgInt.(Config)
-	if !ok {
-		return nil, fmt.Errorf("viper returned wrong type for config")
-	}
-	return &cfg, nil
-}
-
 //GetConfig will return the service config object thus allowing the servie to get created.
 func GetConfig() (*service.Config, error) {
 
-	cfg, err := getViperConfig()
-	if err != nil {
-		return nil, err
-	}
+    var cfg Config
+	err := config.LoadViperConfig(&cfg)
+    if err != nil {
+    	return nil, err
+    }
 
 	handlers := []service.Handler{
 	                    {Method: http.MethodGet, Path: "test", Handler: handlers2.HelloWorld()},

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -1,59 +1,69 @@
 
-# Config  
   
-The objective of the config package is to allow a client to tag a struct with (optional)default values and environment variables and then the config package will use viper to populate a struct. 
-
-## Tag descriptions
-|  Tag|Mandatory  |Description|
-|--|--|--|
-| env |Y  |The environment variable the field value will be retrieved from if the environment variable is present.|
-| default |N  |The default value which will be used if no environment variable is present. N.B. If this is not populated then the default for the type will be used i.e. 0 for int, "" for string, false for bool etc etc.|
-
-N.B. A nested struct does not need tags associated with it. Tags are only required for non struct entries.
-N.N.B. Nested structs will use the "squash" property by default. That means no mapstructure tag is required.
-
-## API
-```
-LoadViperConfig(cfg interface{}) (interface{}, error)
-```
-### Parameters
-|  Name|Input/Output  |Type|Description|
-|--|--|--|--|
-| cfg |input  |interface{}  | All that is a required is an empty struct of the type you want the config read into.  |
-| - |output  |interface{}.  | This output interface should hold the populated configuration struct.(or structs if nested)  |
-| - |output  |error.   |This will hold an error if there are any issues with the tagging or viper was unable to unmarshal |
-
-
     
-### Examples
-#### Simple Struct
-```
-type TestStruct struct {   
-		TestVal string `env:"TEST_VAL" default:"abc"` 
-}  
-```
-#### Nested Struct
-```
-//InnerStruct is the nested struct
-type InnerStruct struct {
-	TestNestInner string `env:"TEST_NEST_INNER" default:"inner"`
-}
+# Config      
+ The objective of the config package is to allow a client to tag a struct with (optional)default values and environment variables and then the config package will use viper to populate a struct.     
+    
+## Tag descriptions
+ |  Tag|Mandatory  |Description|    
+|--|--|--|    
+| env |Y  |The environment variable the field value will be retrieved from if the environment variable is present. N.B. It takes priority over any other tag.|    
+| file |N  |The path to the file to take the default value from. This can be useful for things like passwords where they can be taken from docker / k8s secrets. N.B. If this tag is present and the file can be successfully processed then the default is redundant - if the value can not be read from the file and the default is present then the default is used.|  
+| default |N  |The default value which will be used if no environment variable is present. N.B. If this is not populated then the default for the type will be used i.e. 0 for int, "" for string, false for bool etc etc.|    
+    
+N.B. A nested struct does not need tags associated with it. Tags are only required for non struct entries.    
+N.N.B. Nested structs will use the "squash" property by default. That means no mapstructure tag is required.    
+    
+## Struct API 
+``` LoadViperConfig(cfg interface{}) error ``` 
+### Parameters
+ |  Name|Input/Output  |Type|Description|    
+|--|--|--|--|    
+| cfg |input/output  |interface{}  | A pointer to the config structure which will be populated on return.  |    
+| - |output  |error.   |This will hold an error if there are any issues with the tagging or viper was unable to unmarshal |    
 
-//OuterStruct is the struct containing the nested struct
-type OuterStruct struct {
-	TestNestOuter string `env:"TEST_NEST_OUTER" default:"outer"`
-	InnerStruct
+## File API
+``` LoadViperConfigFromFile(filename string, cfg interface{}) error ``` 
+   ### Parameters
+ |  Name|Input/Output  |Type|Description|    
+|--|--|--|--|    
+| filename |input  |string  | The filename of the config file - this could be yaml, json, xml, env or ini. (i.e. anything which Viper supports)  |
+| cfg |input/output  |interface{}  | A pointer to the config structure which will be populated on return. |    
+
+## Reader API
+``` LoadViperConfigFromReader(reader io.Reader, cfg interface{}, cfgType string) error ``` 
+   ### Parameters
+ |  Name|Input/Output  |Type|Description|    
+|--|--|--|--|    
+| reader |input  |io.Reader  | An io.reader which can be attached to a file, a string, a byte buffer etc etc  |
+| cfg |input/output  |interface{}  | A pointer to the config structure which will be populated on return.  |   
+ | cfgType |input  |string  | The type of config contained within the reader - N.B. This is the range of supported viper types and can be json, yaml/yml, hcl, props, env, toml, ini. See viper docs for the full set.  |   
+| - |output  |error.   |This will hold an error if there are any issues with the tagging or viper was unable to unmarshal |     
+        
+### Examples 
+#### Simple Struct 
+``` 
+type TestStruct struct {       
+   TestVal string `env:"TEST_VAL" default:"abc"`   
+   TestFileVal string `env:"TEST_FILE_VAL" file:"/tmp/test_file_val"`  
+} 
+``` 
+#### Nested Structs
+ ```  
+//InnerStruct is the nested struct type InnerStruct struct {    
+ TestNestInner string `env:"TEST_NEST_INNER" default:"inner"`  
+}    
+ //OuterStruct is the struct containing the nested struct type OuterStruct struct {    
+ TestNestOuter string `env:"TEST_NEST_OUTER" default:"outer"` InnerStruct  
 }
 ```
-#### Handling the response
-The return from LoadViperConfig will be an interface however there is an expectation that it should be of the same type as the empty struct which was passed in. The code below is illustrative of how the return should be handled. N.B. the ok variable and check do not need to be used but if they are not used and for some reason the types do not match the code will panic. 
-```
-cfgInt, err := config.LoadViperConfig(TestStruct{})  
-if err != nil {  
-   //Error handling code
-}  
-cfg, ok := cfgInt.(TestStruct)  
-if !ok {  
-   //Further error handling  
-}
+N.B. This library only supports anonymous nested structs.
+#### Handling the response 
+The struct passed in will be populated upon return if no error.
+``` 
+var testStruct TestStruct
+err := config.LoadViperConfig(&testStruct) 
+if err != nil {      
+	//Error handling code 
+} 
 ```


### PR DESCRIPTION
Problem(s):
-------------
- Reading from an input file and settings up structs for config setup viper differently. (One produces a nested map and one a flat map). It would be good to use one bit of code which would read from a file and also setup environment overrides and defaults based on the struct tags.
- We may want to read some config values from files - e.g. docker / k8s secrets. It would be good to be able to tag the struct so as it would read from a specific file if it exists.
- The API wasn't clean enough. We should have been doing as viper.unmarshal and populating the struct we passed as an argument as opposed to returning an interface and requiring type checks etc.

Solutions:
----------
- When reading from a file(abstracted out to a reader to aid testing) the config populated needs flattened and then merged with the existing config setup.
- New tag introduced which prioritises a file over a default value(though environment variable wins).
- Input struct populated and more reflection added to the setup to deduce nested types. (Also more type safety checking added).


Testing:
--------
- Unit tests added.
- File tested separately.
- Secrets tested separately.