### PR TITLE
Added support for groups in middleware and rate limiting.

### DIFF
--- a/internal/examples/service/main.go
+++ b/internal/examples/service/main.go
@@ -26,13 +26,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Returning from standard HTTP handler ")
 }
 
-//AuthHandler is a placeholder to illustrate an Auth callback working
-func AuthHandler() func(c *gin.Context) {
-	return func(c *gin.Context) {
-		fmt.Println("In auth")
-	}
-}
-
 func middlewareHandler() func(c *gin.Context) {
 	return func(c *gin.Context) {
 		fmt.Println("In middleware")
@@ -42,7 +35,7 @@ func middlewareHandler() func(c *gin.Context) {
 func main() {
 	handlers := []service.Handler{{Method: http.MethodGet, Path: "/test", Handler: BasicTest()},
 		{Method: http.MethodGet, Path: "/handler", Handler: gin.WrapF(handler)},
-		{Method: http.MethodGet, Path: "/testNoRateLimit", Handler: BasicTest(), OverrideRateLimit: true}}
+		{Method: http.MethodGet, Path: "/testNoRateLimit", Handler: BasicTest(), Group: "notratelimited"}}
 
 	mwHandlers := []service.MiddlewareHandler{{Handler: middlewareHandler()}}
 
@@ -62,7 +55,6 @@ func main() {
 		CertConfig:         certConfig,
 		LogLevel:           "WARN",
 		ReadinessCheck:     true,
-		Auth:               AuthHandler(),
 		RateLimit:          rateLimitConfig,
 		MiddlewareHandlers: mwHandlers,
 		Metrics:            true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,6 +101,9 @@ func flattenCfgMap(cfgMap map[string]interface{}) (map[string]interface{}, error
 				return nil, err
 			}
 			err = mergo.Merge(&flatMap, flatInnerMap)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			flatMap[k] = v
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -205,7 +205,7 @@ func TestReadYamlConfigWithSomeDefaults(t *testing.T) {
 	var actual AppConfig
 	err := LoadViperConfigFromReader(reader, &actual, "yaml")
 	if err != nil {
-		t.Errorf("Unexpected error occured %s.", err)
+		t.Errorf("Unexpected error occurred %s.", err)
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Viper config %v is not equal to expected config %v", actual, expected)
@@ -220,12 +220,12 @@ func TestReadYamlConfigWithEnvOverride(t *testing.T) {
 	var actual AppConfig
 	err := os.Setenv("UT_DB_PASSWORD", "environment")
 	if err != nil {
-		t.Errorf("Unexpected error occured %s.", err)
+		t.Errorf("Unexpected error occurred %s.", err)
 	}
 	reader := bytes.NewReader(yamlExample)
 	err = LoadViperConfigFromReader(reader, &actual, "yaml")
 	if err != nil {
-		t.Errorf("Unexpected error occured %s.", err)
+		t.Errorf("Unexpected error occurred %s.", err)
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Viper config %v is not equal to expected config %v", actual, expected)


### PR DESCRIPTION
Problem:
----------
It would be nice to seperate out handlers so as only certain middleware runs against certain endpoints. This would allow us to do things like auth and rate limit on some endpoints but not others.

Solution:
---------
Provide a group field which is essentially a tag as to which gin routergroup the handler will run on. The code when encountering this will create a new group and any middleware / endpoints which belong to this group will run on this router group.

Testing:
---------
Unit testing should suffice.

N.B. Two typos and a missed error check also tested.