### PR TITLE
Updated cert generation to accept existing CA cert files and fixed ineffassign.

### DIFF
--- a/cmd/cert-generator/main.go
+++ b/cmd/cert-generator/main.go
@@ -13,13 +13,9 @@ import (
 var hostnames certificate.HostNames
 
 func main() {
-	CAKeypair, err := certificate.GenerateCA()
-	if err != nil {
-		os.Exit(1)
-	}
-
 	wd, err := os.Getwd()
 	if err != nil {
+		fmt.Printf("Failed to get current working directory %s", err)
 		os.Exit(1)
 	}
 
@@ -27,40 +23,64 @@ func main() {
 	commonName := flag.String("cn", "localhost", "common name for certificate")
 	directory := flag.String("directory", wd, "output to generate certs to")
 	generateCAFiles := flag.Bool("cafiles", false, "whether to output generated CA certs or not")
+	caCert := flag.String("cacertfile", "", "The location of the CA certificate file.")
+	caKey := flag.String("cakeyfile", "", "The location of the CA key file.")
 
+	var CAKeyPair *certificate.KeyPair
 	flag.Parse()
+
+	if caCert != nil && len(*caCert) > 0 && caKey != nil && len(*caKey) > 0 {
+		certBytes, err := ioutil.ReadFile(*caCert)
+		if err != nil {
+			fmt.Printf("Failed to read CA certificate file %s", err)
+			os.Exit(1)
+		}
+
+		keyBytes, err := ioutil.ReadFile(*caKey)
+		if err != nil {
+			fmt.Printf("Failed to read CA private key file %s", err)
+			os.Exit(1)
+		}
+		CAKeyPair = &certificate.KeyPair{Certificate: certBytes, PrivateKey: keyBytes}
+	} else {
+		CAKeyPair, err = certificate.GenerateCA()
+		if err != nil {
+			fmt.Printf("Failed to generate CA cerificate :%s", err)
+			os.Exit(1)
+		}
+	}
 
 	if len(hostnames) == 0 {
 		hostnames = []string{"localhost"}
 	}
 
-	certKeyPair, err := certificate.GenerateSignedCert(CAKeypair, hostnames, *commonName)
+	certKeyPair, err := certificate.GenerateSignedCert(CAKeyPair, hostnames, *commonName)
 	if err != nil {
-		fmt.Println("Unable to generate siged cert.")
+		fmt.Printf("Failed to generate TLS cerificate :%s", err)
 		os.Exit(3)
 	}
 
 	if generateCAFiles != nil && *generateCAFiles {
-		err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "ca.crt")), CAKeypair.Certificate, 0600)
+		err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "ca.crt")), CAKeyPair.Certificate, 0600)
 		if err != nil {
-			fmt.Println("Failed to write CA certificate")
+			fmt.Printf("Failed to write CA certificate file to disk :%s", err)
 			os.Exit(3)
 		}
-		err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "ca.key")), CAKeypair.Certificate, 0600)
+		err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "ca.key")), CAKeyPair.PrivateKey, 0600)
 		if err != nil {
-			fmt.Println("Failed to write CA key.")
+			fmt.Printf("Failed to write CA key file to disk: %s.", err)
 			os.Exit(3)
 		}
 	}
 
 	err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "tls.crt")), certKeyPair.Certificate, 0600)
 	if err != nil {
-		fmt.Println("Failed to write TLS certificate")
+		fmt.Printf("Failed to write TLS cert file to disk: %s.", err)
 		os.Exit(3)
 	}
 	err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "tls.key")), certKeyPair.Certificate, 0600)
 	if err != nil {
-		fmt.Println("Failed to write TLS key.")
+		fmt.Printf("Failed to write TLS key file to disk: %s.", err)
 		os.Exit(3)
 	}
 

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -50,10 +50,13 @@ type TestStruct struct {
 ``` 
 #### Nested Structs
  ```  
-//InnerStruct is the nested struct type InnerStruct struct {    
+//InnerStruct is the nested struct 
+type InnerStruct struct {    
  TestNestInner string `env:"TEST_NEST_INNER" default:"inner"`  
-}    
- //OuterStruct is the struct containing the nested struct type OuterStruct struct {    
+}
+    
+//OuterStruct is the struct containing the nested struct 
+type OuterStruct struct {    
  TestNestOuter string `env:"TEST_NEST_OUTER" default:"outer"` InnerStruct  
 }
 ```

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -182,7 +182,6 @@ func setupEndpoints(handlers []Handler, engine *gin.Engine) {
 //NewService will setup a new service based on the config and return this service.
 func NewService(cfg *Config) (*Service, error) {
 	//Router map only required in the context of this function
-	routerMap = make(map[string]*gin.RouterGroup)
 	if len(cfg.Handlers) == 0 {
 		return nil, fmt.Errorf("no handlers registered for service")
 	}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -61,6 +61,9 @@ func checkResponseCode(method string, url string, cfg Config, code int, reqHeade
 	}
 
 	rr, err := sendRequest(svc, method, url, reqHeaders...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create  client request due to error %s", err)
+	}
 	if rr.Code != code {
 		return nil, fmt.Errorf("Unexpected response code %d. Expected %d", rr.Code, code)
 	}

--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -24,11 +24,32 @@ then
     exit 1
 fi
 
-echo "Do you want the CA certificate and key generated?(y|n)"
-read generateca
-validate_choice $generateca
-if [ "$generateca" == "y" ];then
-    CA_ARGS="-cafiles true"
+echo "Do you want to use an existing CA cert and private key to generate your TLS certs with?(y|n)"
+read existingca
+validate_choice $existingca
+if [ "$existingca" == "y" ];then
+    echo "Please enter the absolute path to the CA certificate:"
+    read cacert
+    if [ ! -e "$cacert" ]
+    then
+        echo "CA certificate $cacert does not exist."
+        exit 1
+    fi
+    echo "Please enter the absolute path to the CA private key file:"
+    read cakey
+    if [ ! -e "$cakey" ]
+    then
+        echo "CA private key $cakey does not exist."
+        exit 1
+    fi
+    CA_ARGS="-cacertfile $cacert -cakeyfile $cakey"
+else
+    echo "Do you want the CA certificate and key written to disk too?(y|n)"
+    read generateca
+    validate_choice $generateca
+    if [ "$generateca" == "y" ];then
+        CA_ARGS="-cafiles true"
+    fi
 fi
 
 echo "Enter the comman name(cn) you want to generate the certificate for(localhost):"

--- a/scripts/generate-service.sh
+++ b/scripts/generate-service.sh
@@ -76,7 +76,6 @@ fi
 echo "Would you like the default prometheus metrics?(y|n)"
 read metrics < /dev/stdin
 validate_choice $metrics
-BUILDARGS="${BUILDARGS} -X main.readinessCheckEnabled=${metrics}"'"'
+BUILDARGS="${BUILDARGS} -X main.metricsEnabled=${metrics}"'"'
 
-#cmd="go run $BUILDARGS cmd/service-generator/main.go"
 eval "go run $BUILDARGS cmd/service-generator/main.go"


### PR DESCRIPTION
Problem:
---------
Not a problem as such but if you wanted to generate a new self signed cert from the same CA as an old self signed cert that wasn't possible.

Solution:
---------
Allow self signed certs to be generated from input CA cert and key files. 

Testing:
---------
- Generated self signed cert with new CA certs. These were used as output.
- Tested that these files could then be used as input to the next run.
- Tested via CLI and via the run script.