### PR TITLE
Fixing problem with file extension including dot

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,12 +115,16 @@ func flattenCfgMap(cfgMap map[string]interface{}) (map[string]interface{}, error
 //The config will be read from a file but environment variables override and default values can still be set. The file can
 // be anything that Viper supports. N.B. This only supports anonymous nested structs.
 func LoadViperConfigFromFile(filename string, cfg interface{}) error {
+	if len(filepath.Ext(filename)) < 1 {
+		return fmt.Errorf("missing file extension")
+	}
+
 	reader, err := os.Open(filepath.Clean(filename))
 	if err != nil {
 		return err
 	}
 
-	err = LoadViperConfigFromReader(reader, cfg, filepath.Ext(filename))
+	err = LoadViperConfigFromReader(reader, cfg, filepath.Ext(filename)[1:])
 
 	//N.B. Deferring a file close is bad practise so making it key part of function.
 	fileCloseErr := reader.Close()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -231,3 +231,12 @@ func TestReadYamlConfigWithEnvOverride(t *testing.T) {
 		t.Errorf("Viper config %v is not equal to expected config %v", actual, expected)
 	}
 }
+
+func TestLoadViperConfigFromFileNoFileExtension(t *testing.T) {
+	os.Clearenv()
+	var actual AppConfig
+	err := LoadViperConfigFromFile("./nofile", &actual)
+	if err == nil {
+		t.Error("File with no extension should error")
+	}
+}


### PR DESCRIPTION
Added check that config file has an extension.
Fixed LoadViperConfigFromFile, removing dot from extension to give filetype.

Added unit test to check file with no extension throws error
