### PR TITLE
(BUG) Allow value from a file to be any type.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,8 @@ func setupViperConfig(cfg interface{}, v *viper.Viper) error {
 			if err != nil {
 				logrus.Warnf("Unable to read file %s due to error %s.", fileTag, err)
 			}
-			v.SetDefault(f.Name, string(fileBytes))
+
+			v.SetDefault(f.Name, fileBytes)
 			fileDefaultSet = true
 		}
 


### PR DESCRIPTION
Problem:
The type of the variable being read in by config can only be string as an unnecessary cast has been done.

Solution:
Remove unnecessary cast.

Testing:
Tested with byte array which previously didn't work and tested with string which worked previously but now isn't hard coded. Worked as expected.