### PR TITLE
(MAINT) Fix issue with tls output file.

### DIFF
--- a/cmd/cert-generator/main.go
+++ b/cmd/cert-generator/main.go
@@ -66,6 +66,7 @@ func main() {
 			fmt.Printf("Failed to write CA certificate file to disk :%s", err)
 			os.Exit(3)
 		}
+
 		err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "ca.key")), CAKeyPair.PrivateKey, 0600)
 		if err != nil {
 			fmt.Printf("Failed to write CA key file to disk: %s.", err)
@@ -78,7 +79,8 @@ func main() {
 		fmt.Printf("Failed to write TLS cert file to disk: %s.", err)
 		os.Exit(3)
 	}
-	err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "tls.key")), certKeyPair.Certificate, 0600)
+
+	err = ioutil.WriteFile(fmt.Sprintf(filepath.Join(filepath.Clean(*directory), "tls.key")), certKeyPair.PrivateKey, 0600)
 	if err != nil {
 		fmt.Printf("Failed to write TLS key file to disk: %s.", err)
 		os.Exit(3)


### PR DESCRIPTION
Problem:
The TLS certificate was written to the tls key file by mistake.

Solution:
Write the key to the key file rather than the certificate.

Testing:
Ran through the wizard scripting process and now works as expected.