### PR TITLE
Add the ability to provide your own error handler.

### DIFF
--- a/cmd/cert-generator/main.go
+++ b/cmd/cert-generator/main.go
@@ -59,6 +59,7 @@ func main() {
 		hostnames = []string{"localhost"}
 	}
 
+	fmt.Println(*commonName)
 	certKeyPair, err := certificate.GenerateSignedCert(CAKeyPair, hostnames, *commonName)
 	if err != nil {
 		fmt.Printf("Failed to generate TLS cerificate :%s", err)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/cnjack/throttle v0.0.0-20160727064406-525175b56e18
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.7
 	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab // indirect

--- a/pkg/service/README.md
+++ b/pkg/service/README.md
@@ -35,6 +35,7 @@ type Config struct {
   RateLimit          *RateLimitConfig         //Optional rate limiting config  
   MiddlewareHandlers []MiddlewareHandler      //Optional middleware handlers which will be run on every request  
   Metrics            bool                     //Optional. If true a prometheus metrics endpoint will be exposed at /metrics/  
+  ErrorHandler       *MiddlewareHandler       //Optional. If true a handler will be added to the end of the chain.
 }  
   
 //Handler will hold all the callback handlers to be registered. N.B. gin will be used.


### PR DESCRIPTION
Problem:
---------
It would be ideal that a "client" could write their own handler so as any of their endpoints would exercise the same code and go through the same error handling. This is a feature which would best fit in the service library itself.

Solution:
---------
Provide the ability to pass through an error handler. This handler is of gin signature but native go handlers can just call gin.WrapF. This error handler will be called at the end of each HTTP request and so will enable error handling and logging to be performed.

Testing:
---------
Tested through unit testing. N.B. The most of the work will be done in the client here. Error handler always invoked at the end. N.B. The status code or output should not be set before code exercised in here.

N.N.B. A little bit added to the makefile to capture coverage. An additional test added for invalid test method due to being missing.