### PR TITLE
Add sliceutil package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,13 @@ linters:
     - varcheck
 
 linters-settings:
+  ireturn:
+    allow:
+      - anon
+      - empty
+      - error
+      - generic
+      - stdlib
   lll:
     tab-width: 4
   tagliatelle:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.14.0
+	github.com/stretchr/testify v1.8.3
 	github.com/toorop/gin-logrus v0.0.0-20210225092905-2c785434f26f
 	gotest.tools v2.2.0+incompatible
 )
@@ -21,6 +22,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
@@ -43,6 +45,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
@@ -105,6 +106,7 @@ github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iauee
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=

--- a/pkg/sliceutil/sliceutil.go
+++ b/pkg/sliceutil/sliceutil.go
@@ -1,0 +1,41 @@
+// Package sliceutil provides useful functions for working with slices not provided by the standard library.
+package sliceutil
+
+import (
+	"reflect"
+	"strings"
+)
+
+// RemoveZeroValues returns a copy of s with all zero-valued elements removed.
+func RemoveZeroValues[S ~[]E, E any](s S) S {
+	updatedSlice := make([]E, 0)
+	for _, v := range s {
+		if !reflect.ValueOf(v).IsZero() {
+			updatedSlice = append(updatedSlice, v)
+		}
+	}
+
+	return updatedSlice
+}
+
+// ToLower returns a copy of s with all letters in all elements mapped to lower case.
+func ToLower(s []string) []string {
+	lowerCasedSlice := make([]string, 0, len(s))
+	for _, v := range s {
+		lowerCased := strings.ToLower(v)
+		lowerCasedSlice = append(lowerCasedSlice, lowerCased)
+	}
+
+	return lowerCasedSlice
+}
+
+// Trim returns a copy of s with all leading and trailing whitespace in all elements removed.
+func Trim(s []string) []string {
+	trimmedSlice := make([]string, 0, len(s))
+	for _, v := range s {
+		trimmed := strings.TrimSpace(v)
+		trimmedSlice = append(trimmedSlice, trimmed)
+	}
+
+	return trimmedSlice
+}

--- a/pkg/sliceutil/sliceutil_test.go
+++ b/pkg/sliceutil/sliceutil_test.go
@@ -1,0 +1,44 @@
+package sliceutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveZeroValues(t *testing.T) {
+	boolSlice := []bool{false, false, false}
+	require.Equal(t, []bool{}, RemoveZeroValues(boolSlice))
+
+	intSlice := []int{1, 987, 0}
+	require.Equal(t, []int{1, 987}, RemoveZeroValues(intSlice))
+
+	strSlice := []string{"hello", "world", ""}
+	require.Equal(t, []string{"hello", "world"}, RemoveZeroValues(strSlice))
+
+	str1 := "hello"
+	str2 := "world"
+	str1Ptr := &str1
+	str2Ptr := &str2
+	var nilStrPtr *string
+
+	strPtrSlice := []*string{&str1, &str2, nilStrPtr, nil}
+	require.Equal(t, []*string{str1Ptr, str2Ptr}, RemoveZeroValues(strPtrSlice))
+
+	type testStruct struct {
+		flag bool
+	}
+
+	ts := []testStruct{{flag: true}, {flag: false}}
+	require.Equal(t, []testStruct{{flag: true}}, RemoveZeroValues(ts))
+}
+
+func TestToLower(t *testing.T) {
+	s := []string{"apples", "ORANGES", "**Pears**", "bAnAnAs-123"}
+	require.Equal(t, []string{"apples", "oranges", "**pears**", "bananas-123"}, ToLower(s))
+}
+
+func TestTrim(t *testing.T) {
+	s := []string{"no-space", "middle space", " left-space", "right-space ", "   surrounding-space   "}
+	require.Equal(t, []string{"no-space", "middle space", "left-space", "right-space", "surrounding-space"}, Trim(s))
+}


### PR DESCRIPTION
Adds a `sliceutil` package, which is intended to provide useful functions for working with slices not provided by the standard library. The package initially provides the following functions:
* `RemoveZeroValues`
* `ToLower`
* `Trim`

Accompanying unit tests have been added, and the config for the `ireturn` linter has been updated to permit returning generic interfaces.