### PR TITLE
(MAINT) Add ability to generate a CRL to certificates package.

### DIFF
--- a/cmd/cert-generator/main.go
+++ b/cmd/cert-generator/main.go
@@ -28,6 +28,7 @@ func main() {
 	commonName := flag.String("cn", "localhost", "common name for certificate")
 	directory := flag.String("directory", wd, "output to generate certs to")
 	generateCAFiles := flag.Bool("cafiles", false, "whether to output generated CA certs or not")
+	generateCRLFile := flag.Bool("crlfile", false, "whether to output a CRL or not")
 	caCert := flag.String("cacertfile", "", "The location of the CA certificate file.")
 	caKey := flag.String("cakeyfile", "", "The location of the CA key file.")
 
@@ -94,5 +95,20 @@ func main() {
 	if err != nil {
 		fmt.Printf("Failed to write TLS key file to disk: %s.", err)
 		os.Exit(errorExitCode)
+	}
+
+	if generateCRLFile != nil && *generateCRLFile {
+		crl, err := certificate.GenerateCRL(CAKeyPair)
+		if err != nil {
+			fmt.Printf("Failed to generate CRL file: %s.", err)
+			os.Exit(errorExitCode)
+		}
+
+		err = os.WriteFile(filepath.Join(filepath.Clean(*directory), "tls.crl"), crl,
+			fileModeUserReadWriteOnly)
+		if err != nil {
+			fmt.Printf("Failed to write CRL file to disk: %s.", err)
+			os.Exit(errorExitCode)
+		}
 	}
 }

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -20,6 +20,34 @@ func TestGenerateCAWorks(t *testing.T) {
 	}
 }
 
+func TestGenerateCRLWorks(t *testing.T) {
+	keyPair, err := GenerateCA()
+	if err != nil {
+		t.Errorf("Unable to generate cert due to %s", err)
+	}
+
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(keyPair.Certificate))
+	if !ok {
+		t.Error("failed to parse root certificate")
+	}
+
+	crlPem, err := GenerateCRL(keyPair)
+	if err != nil {
+		t.Errorf("failed to generate CRL due to error %s", err)
+	}
+
+	crl, _ := pem.Decode(crlPem)
+	if crl == nil {
+		t.Error("failed to parse CRL due to nil response from pem decode")
+	}
+
+	_, err = x509.ParseRevocationList(crl.Bytes)
+	if err != nil {
+		t.Errorf("failed to parse CRL due to error %s", err)
+	}
+}
+
 func TestGenerateCertLocalhostWorks(t *testing.T) {
 	rootKeyPair, err := GenerateCA()
 	if err != nil {

--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -48,8 +48,15 @@ else
     read generateca
     validate_choice $generateca
     if [ "$generateca" == "y" ];then
-        CA_ARGS="-cafiles true"
+        CA_ARGS="-cafiles"
     fi
+fi
+
+echo "Do you want to generate a CRL?(y|n)"
+read generatecrl
+validate_choice $generatecrl
+if [ "$generatecrl" == "y" ];then
+  CRL_ARGS="-crlfile"
 fi
 
 echo "Enter the comman name(cn) you want to generate the certificate for(localhost):"
@@ -84,5 +91,5 @@ else
     done
 fi
 
-ARGS="$DIR_ARGS $CA_ARGS $CN_ARGS $HOST_ARGS"
+ARGS="$DIR_ARGS $CA_ARGS $CN_ARGS $CRL_ARGS $HOST_ARGS"
 go run cmd/cert-generator/main.go $ARGS


### PR DESCRIPTION
Problem
If using client certs NGINX requires a CRL file(even if empty).

Solution:
Generate additional CRL file.

Testing:
Tested locally and works as expected.