### PR TITLE
(MAINT) Allow config values to be mandatory

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -14,8 +14,6 @@ import (
 	"math/big"
 	"net"
 	"time"
-
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -230,8 +228,6 @@ func populateDNSNamesAndIPs(hostnames HostNames, dnsNames []string, ips []net.IP
 			for _, ip := range ipList {
 				ips = append(ips, net.ParseIP(ip))
 			}
-		} else {
-			logrus.Errorf("Could not resolve hostname %s\n", hostname)
 		}
 		dnsNames = append(dnsNames, hostname)
 	}

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -5,12 +5,14 @@
  The objective of the config package is to allow a client to tag a struct with (optional)default values and environment variables and then the config package will use viper to populate a struct.     
     
 ## Tag descriptions
- |  Tag|Mandatory  |Description|    
-|--|--|--|    
-| env |Y  |The environment variable the field value will be retrieved from if the environment variable is present. N.B. It takes priority over any other tag.|    
-| file |N  |The path to the file to take the default value from. This can be useful for things like passwords where they can be taken from docker / k8s secrets. N.B. If this tag is present and the file can be successfully processed then the default is redundant - if the value can not be read from the file and the default is present then the default is used.|  
-| default |N  |The default value which will be used if no environment variable is present. N.B. If this is not populated then the default for the type will be used i.e. 0 for int, "" for string, false for bool etc etc.|    
-    
+ | Tag       |Mandatory  | Description                                                                                                                                                                                                                                                                                                                                                 |    
+|-----------|--|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|    
+| env       |Y  | The environment variable the field value will be retrieved from if the environment variable is present. N.B. It takes priority over any other tag.                                                                                                                                                                                                          |    
+| file      |N  | The path to the file to take the default value from. This can be useful for things like passwords where they can be taken from docker / k8s secrets. N.B. If this tag is present and the file can be successfully processed then the default is redundant - if the value can not be read from the file and the default is present then the default is used. |  
+| default   |N  | The default value which will be used if no environment variable is present. N.B. If this is not populated then the default for the type will be used i.e. 0 for int, "" for string, false for bool etc etc.                                                                                                                                                 |
+ | mandatory |N  | Whether the field is mandatory or not. N.B. If this is not populated then it will default to false so the field will be optional.                                                                                                                                                                                                                           |    
+
+
 N.B. A nested struct does not need tags associated with it. Tags are only required for non struct entries.    
 N.N.B. Nested structs will use the "squash" property by default. That means no mapstructure tag is required.    
     

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var yamlExample = []byte(`db:
@@ -96,6 +98,11 @@ type WebServer struct {
 type AppConfig struct {
 	Database
 	WebServer
+}
+
+// MandatorySet has config with a value that is mandatory
+type MandatorySet struct {
+	TestVal string `env:"MANDATORY_TEST_VAL" mandatory:"true"`
 }
 
 func TestNoTagsErrors(t *testing.T) {
@@ -241,4 +248,21 @@ func TestLoadViperConfigFromFileNoFileExtension(t *testing.T) {
 	if err == nil {
 		t.Error("File with no extension should error")
 	}
+}
+
+func TestMandatorySet(t *testing.T) {
+	os.Clearenv()
+
+	err := os.Setenv("MANDATORY_TEST_VAL", "blah")
+	if err != nil {
+		t.Errorf("Unexpected error occurred %s.", err)
+	}
+
+	var actual MandatorySet
+	err = LoadViperConfig(&actual)
+	assert.NoError(t, err)
+
+	os.Clearenv()
+	err = LoadViperConfig(&actual)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Problem:
We want to be able to specify that certain configuration fields are mandatory so we can fail if needbe.

Solution:
Add a tag to specify mandatory and default to false so it's backwards compatible.

Testing:
New unit tests added.