### PR TITLE
(MAINT) Allow configurable paths to ignore logging.

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -38,6 +38,7 @@ type Config struct {
 	MiddlewareHandlers []MiddlewareHandler      // Optional middleware handlers which will be run on every request.
 	Metrics            bool                     // Optional. If true add a prometheus endpoint.
 	ErrorHandler       *MiddlewareHandler       // Optional. If true a handler will be added to the end of the chain.
+	LogIgnorePaths     []string                 // Optional. If set, these paths will not be logged by the gin logger.
 }
 
 // Handler will hold all the callback handlers to be registered. N.B. gin will be used.
@@ -247,7 +248,7 @@ func NewService(cfg *Config) (*Service, error) {
 	gin.SetMode(gin.ReleaseMode)
 	router := gin.New()
 	logger := log.CreateLogger(cfg.LogLevel)
-	router.Use(ginlogrus.Logger(logger))
+	router.Use(ginlogrus.Logger(logger, cfg.LogIgnorePaths...))
 
 	// Set CORS to the default if it's enabled and no override passed in.
 	setupCors(router, cfg.Cors)


### PR DESCRIPTION
Problem:
Health check logs are too noisy so configuring a mechanism to turn off logging on certain paths.

Solution:
Introduce config and use gin logging with it's ignore.

Testing:
Tested in my own project with a healthcheck URI and works as expected.